### PR TITLE
fix: add missing bugs metadata field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,13 @@
 {
   "name": "@larksuiteoapi/lark-mcp",
   "version": "0.5.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/larksuite/lark-openapi-mcp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/larksuite/lark-openapi-mcp/issues"
+  },
   "description": "Feishu/Lark OpenAPI MCP",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Adds missing package metadata fields to `package.json`.

This allows npm tooling and consumers to correctly resolve package metadata.