### PR TITLE
feat: add builtin sheets range read tools (v2 values API)

### DIFF
--- a/src/mcp-tool/tools/en/builtin-tools/index.ts
+++ b/src/mcp-tool/tools/en/builtin-tools/index.ts
@@ -1,6 +1,7 @@
 import { docxBuiltinToolName, docxBuiltinTools } from './docx/builtin';
 import { imBuiltinToolName, imBuiltinTools } from './im/buildin';
+import { sheetsBuiltinToolName, sheetsBuiltinTools } from './sheets/builtin';
 
-export const BuiltinTools = [...docxBuiltinTools, ...imBuiltinTools];
+export const BuiltinTools = [...docxBuiltinTools, ...imBuiltinTools, ...sheetsBuiltinTools];
 
-export type BuiltinToolName = docxBuiltinToolName | imBuiltinToolName;
+export type BuiltinToolName = docxBuiltinToolName | imBuiltinToolName | sheetsBuiltinToolName;

--- a/src/mcp-tool/tools/en/builtin-tools/sheets/builtin.ts
+++ b/src/mcp-tool/tools/en/builtin-tools/sheets/builtin.ts
@@ -1,0 +1,131 @@
+import { McpTool } from '../../../../types';
+import * as lark from '@larksuiteoapi/node-sdk';
+import { z } from 'zod';
+
+// Tool name type
+export type sheetsBuiltinToolName = 'sheets.builtin.readRange' | 'sheets.builtin.readMultipleRanges';
+
+const valueRenderOptionSchema = z
+  .enum(['ToString', 'Formula', 'FormattedValue', 'UnformattedValue'])
+  .describe(
+    'How cell values are rendered. ToString: returns values as strings; Formula: returns formulas; FormattedValue: returns values as displayed; UnformattedValue: returns raw values (default)',
+  )
+  .optional();
+
+const dateTimeRenderOptionSchema = z
+  .enum(['FormattedString'])
+  .describe(
+    'How date/time values are rendered. FormattedString: returns dates as formatted strings. When omitted, dates are returned as serial numbers',
+  )
+  .optional();
+
+export const larkSheetsBuiltinReadRangeTool: McpTool = {
+  project: 'sheets',
+  name: 'sheets.builtin.readRange',
+  accessTokens: ['user', 'tenant'],
+  description:
+    '[Feishu/Lark]-Docs-Sheets-Read Range-Read cell values from a spreadsheet range. Use sheets.v3.spreadsheetSheet.query to get sheet IDs first',
+  schema: {
+    data: z.object({
+      spreadsheet_token: z.string().describe('Spreadsheet token, the unique identifier of the spreadsheet'),
+      range: z
+        .string()
+        .describe(
+          "Cell range in the format 'sheetId!A1:D5'. Passing only 'sheetId' reads the whole sheet. sheetId comes from sheets.v3.spreadsheetSheet.query",
+        ),
+      valueRenderOption: valueRenderOptionSchema,
+      dateTimeRenderOption: dateTimeRenderOptionSchema,
+    }),
+    useUAT: z.boolean().describe('Use user access token, otherwise use tenant access token').optional(),
+  },
+  customHandler: async (client, params, options): Promise<any> => {
+    try {
+      const { userAccessToken } = options || {};
+      const { spreadsheet_token, range, valueRenderOption, dateTimeRenderOption } = params.data;
+      const request = {
+        method: 'GET',
+        url: `/open-apis/sheets/v2/spreadsheets/${spreadsheet_token}/values/${encodeURIComponent(range)}`,
+        params: { valueRenderOption, dateTimeRenderOption },
+      };
+      const response =
+        userAccessToken && params.useUAT
+          ? await client.request(request, lark.withUserAccessToken(userAccessToken))
+          : await client.request(request);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(response.data ?? response),
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify((error as any)?.response?.data || (error as Error)?.message || error),
+          },
+        ],
+      };
+    }
+  },
+};
+
+export const larkSheetsBuiltinReadMultipleRangesTool: McpTool = {
+  project: 'sheets',
+  name: 'sheets.builtin.readMultipleRanges',
+  accessTokens: ['user', 'tenant'],
+  description:
+    '[Feishu/Lark]-Docs-Sheets-Read Multiple Ranges-Read cell values from multiple ranges of a spreadsheet in one call',
+  schema: {
+    data: z.object({
+      spreadsheet_token: z.string().describe('Spreadsheet token, the unique identifier of the spreadsheet'),
+      ranges: z
+        .array(z.string())
+        .min(1)
+        .describe(
+          "Cell ranges in the format ['sheetId!A1:D5', 'sheetId!F1:H5']. sheetId comes from sheets.v3.spreadsheetSheet.query",
+        ),
+      valueRenderOption: valueRenderOptionSchema,
+      dateTimeRenderOption: dateTimeRenderOptionSchema,
+    }),
+    useUAT: z.boolean().describe('Use user access token, otherwise use tenant access token').optional(),
+  },
+  customHandler: async (client, params, options): Promise<any> => {
+    try {
+      const { userAccessToken } = options || {};
+      const { spreadsheet_token, ranges, valueRenderOption, dateTimeRenderOption } = params.data;
+      const request = {
+        method: 'GET',
+        url: `/open-apis/sheets/v2/spreadsheets/${spreadsheet_token}/values_batch_get`,
+        params: { ranges: ranges.join(','), valueRenderOption, dateTimeRenderOption },
+      };
+      const response =
+        userAccessToken && params.useUAT
+          ? await client.request(request, lark.withUserAccessToken(userAccessToken))
+          : await client.request(request);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(response.data ?? response),
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify((error as any)?.response?.data || (error as Error)?.message || error),
+          },
+        ],
+      };
+    }
+  },
+};
+
+export const sheetsBuiltinTools = [larkSheetsBuiltinReadRangeTool, larkSheetsBuiltinReadMultipleRangesTool];

--- a/src/mcp-tool/tools/zh/builtin-tools/index.ts
+++ b/src/mcp-tool/tools/zh/builtin-tools/index.ts
@@ -1,6 +1,7 @@
 import { docxBuiltinToolName, docxBuiltinTools } from './docx/builtin';
 import { imBuiltinToolName, imBuiltinTools } from './im/buildin';
+import { sheetsBuiltinToolName, sheetsBuiltinTools } from './sheets/builtin';
 
-export const BuiltinTools = [...docxBuiltinTools, ...imBuiltinTools];
+export const BuiltinTools = [...docxBuiltinTools, ...imBuiltinTools, ...sheetsBuiltinTools];
 
-export type BuiltinToolName = docxBuiltinToolName | imBuiltinToolName;
+export type BuiltinToolName = docxBuiltinToolName | imBuiltinToolName | sheetsBuiltinToolName;

--- a/src/mcp-tool/tools/zh/builtin-tools/sheets/builtin.ts
+++ b/src/mcp-tool/tools/zh/builtin-tools/sheets/builtin.ts
@@ -1,0 +1,128 @@
+import { McpTool } from '../../../../types';
+import * as lark from '@larksuiteoapi/node-sdk';
+import { z } from 'zod';
+
+// Tool name type
+export type sheetsBuiltinToolName = 'sheets.builtin.readRange' | 'sheets.builtin.readMultipleRanges';
+
+const valueRenderOptionSchema = z
+  .enum(['ToString', 'Formula', 'FormattedValue', 'UnformattedValue'])
+  .describe(
+    '单元格数据格式。ToString：返回纯文本值；Formula：返回公式；FormattedValue：返回格式化后的值；UnformattedValue：返回原始值（默认）',
+  )
+  .optional();
+
+const dateTimeRenderOptionSchema = z
+  .enum(['FormattedString'])
+  .describe('日期时间单元格数据格式。FormattedString：返回格式化后的字符串。不传时日期以序列号形式返回')
+  .optional();
+
+export const larkSheetsBuiltinReadRangeTool: McpTool = {
+  project: 'sheets',
+  name: 'sheets.builtin.readRange',
+  accessTokens: ['user', 'tenant'],
+  description:
+    '[飞书/Lark]-云文档-电子表格-读取单个范围-读取电子表格中指定范围的单元格数据。可先调用 sheets.v3.spreadsheetSheet.query 获取工作表 ID',
+  schema: {
+    data: z.object({
+      spreadsheet_token: z.string().describe('电子表格的唯一标识 token'),
+      range: z
+        .string()
+        .describe(
+          "查询范围，格式为 'sheetId!A1:D5'。仅传 'sheetId' 时读取整个工作表。sheetId 可通过 sheets.v3.spreadsheetSheet.query 获取",
+        ),
+      valueRenderOption: valueRenderOptionSchema,
+      dateTimeRenderOption: dateTimeRenderOptionSchema,
+    }),
+    useUAT: z.boolean().describe('是否使用用户身份请求，否则使用应用身份').optional(),
+  },
+  customHandler: async (client, params, options): Promise<any> => {
+    try {
+      const { userAccessToken } = options || {};
+      const { spreadsheet_token, range, valueRenderOption, dateTimeRenderOption } = params.data;
+      const request = {
+        method: 'GET',
+        url: `/open-apis/sheets/v2/spreadsheets/${spreadsheet_token}/values/${encodeURIComponent(range)}`,
+        params: { valueRenderOption, dateTimeRenderOption },
+      };
+      const response =
+        userAccessToken && params.useUAT
+          ? await client.request(request, lark.withUserAccessToken(userAccessToken))
+          : await client.request(request);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(response.data ?? response),
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify((error as any)?.response?.data || (error as Error)?.message || error),
+          },
+        ],
+      };
+    }
+  },
+};
+
+export const larkSheetsBuiltinReadMultipleRangesTool: McpTool = {
+  project: 'sheets',
+  name: 'sheets.builtin.readMultipleRanges',
+  accessTokens: ['user', 'tenant'],
+  description: '[飞书/Lark]-云文档-电子表格-读取多个范围-一次调用读取电子表格中多个范围的单元格数据',
+  schema: {
+    data: z.object({
+      spreadsheet_token: z.string().describe('电子表格的唯一标识 token'),
+      ranges: z
+        .array(z.string())
+        .min(1)
+        .describe(
+          "查询范围列表，格式为 ['sheetId!A1:D5', 'sheetId!F1:H5']。sheetId 可通过 sheets.v3.spreadsheetSheet.query 获取",
+        ),
+      valueRenderOption: valueRenderOptionSchema,
+      dateTimeRenderOption: dateTimeRenderOptionSchema,
+    }),
+    useUAT: z.boolean().describe('是否使用用户身份请求，否则使用应用身份').optional(),
+  },
+  customHandler: async (client, params, options): Promise<any> => {
+    try {
+      const { userAccessToken } = options || {};
+      const { spreadsheet_token, ranges, valueRenderOption, dateTimeRenderOption } = params.data;
+      const request = {
+        method: 'GET',
+        url: `/open-apis/sheets/v2/spreadsheets/${spreadsheet_token}/values_batch_get`,
+        params: { ranges: ranges.join(','), valueRenderOption, dateTimeRenderOption },
+      };
+      const response =
+        userAccessToken && params.useUAT
+          ? await client.request(request, lark.withUserAccessToken(userAccessToken))
+          : await client.request(request);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(response.data ?? response),
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify((error as any)?.response?.data || (error as Error)?.message || error),
+          },
+        ],
+      };
+    }
+  },
+};
+
+export const sheetsBuiltinTools = [larkSheetsBuiltinReadRangeTool, larkSheetsBuiltinReadMultipleRangesTool];


### PR DESCRIPTION
Adds two read-only builtin tools for reading spreadsheet cell values, requested in #71:

- `sheets.builtin.readRange` — read one range (`GET /open-apis/sheets/v2/spreadsheets/:token/values/:range`). Passing only a sheet ID as the range reads the whole sheet.
- `sheets.builtin.readMultipleRanges` — read several ranges in one call (`values_batch_get`)

**Why builtin instead of gen-tools**: the cell-values endpoints only exist in the v2 API surface, which the generated `sheets_v3` tools don't cover (they handle metadata, filters and find/replace, but provide no way to read cell contents). This follows the existing `docx.builtin.*` / `im.builtin.*` customHandler pattern.

**Design notes**
- Not added to any preset, so default behavior is unchanged. Enable via explicit tool names, or `allowProjects: ['sheets']` in the library API. Happy to add them to `preset.doc.default` if you prefer.
- Supports `valueRenderOption` / `dateTimeRenderOption`, user and tenant tokens, EN/ZH tool descriptions.
- Read-only; no new dependencies; no changes to existing tools.

**Verification**
- Build (`tsc`) and `prettier --check` pass; tests: 398 passed, the 9 pre-existing failures on `main` are unchanged
- Tool registration verified for both EN/ZH registries (no duplicate names, project filter picks them up)
- Request construction verified against a stub client: single range renders as `/values/sheetId!A1%3AD5`, batch renders as `?ranges=sheetId!A1:D5,sheetId!F1:H5` (the documented format); empty `ranges` is rejected by schema
- Both endpoints verified end-to-end with authenticated calls against a live international tenant (`quark-inc.jp.larksuite.com`): known values (ASCII, Japanese, numbers) round-trip exactly through both the single-range and batch endpoints, including `valueRenderOption`

Resolves #71